### PR TITLE
Update of wrong spelled value in value list

### DIFF
--- a/schema/ERMS.xsd
+++ b/schema/ERMS.xsd
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!-- E-ARK ERMS schema version 2.1.3 2023-11-03 -->
 <!-- E-ARK ERMS schema version 2.1.2 2022-12-09 -->
 <!-- E-ARK ERMS schema version 2.1.1 2022-06-20 -->
 <!-- E-ARK ERMS schema version 2.1 2021-08-31 -->
 <!-- E-ARK ERMS schema version 2.0 2020-08-01 -->
-<!-- Chganges includes correction of elements name and camelcasing, valuelist corrections and lowercase and underscore used instead of spaces.-->
+<!-- Changes includes correction of elements name and camelcasing, valuelist corrections and lowercase and underscore used instead of spaces.-->
 <!-- E-ARK ERMS schema version 1.0 2019-05-31 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="https://DILCIS.eu/XML/ERMS" targetNamespace="https://DILCIS.eu/XML/ERMS"
     elementFormDefault="qualified">
@@ -316,11 +317,12 @@
             <xs:annotation>
                 <xs:documentation xml:lang="en">State whether the record is physical, digital, both or if the statment dont apply.</xs:documentation>
                 <xs:documentation xml:lang="en">2020-02-11 update of value list. "Dont apply" -> "Does not apply" </xs:documentation>
+                <xs:documentation xml:lang="en">2023-11-02 update of value list. "digitial" -> "digital"</xs:documentation>
             </xs:annotation>
             <xs:simpleType>
                 <xs:restriction base="xs:string">
                     <xs:enumeration value="physical"/>
-                    <xs:enumeration value="digitial"/>
+                    <xs:enumeration value="digital"/>
                     <xs:enumeration value="physcical_and_digital"/>
                     <xs:enumeration value="does_not_apply"/>
                 </xs:restriction>

--- a/schema/Index.md
+++ b/schema/Index.md
@@ -1,11 +1,11 @@
 ---
-title: CS E-ARK-ERMS Associated Schema Files
+title: E-ARK CITS ERMS Associated Schema Files
 ---
-CSERMS Associated Schema Files
+CITS ERMS Associated Schema Files
 =======================
 
 - [ERMS Schema](./ERMS.xsd)
-  Version 2.1.2 of the ERMS schema
+  Version 2.1.3 of the ERMS schema
 - [ERMS Schematron rules](./ERMS.sch)
   Version 2.0 of the Schematron rules for validation
 - [ERMS Schema Doumentation (pdf)](./ERMS_Schema_Documentation/pdf/ERMS.pdf)


### PR DESCRIPTION
Following #31  the wrongly spelled value in the value list in the schema have been updated. The value in the specification itself is correct!

Closes #31 